### PR TITLE
DAP-03 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a reference interoperation test harness, using [draft-dcook-ppm-dap-interop-test-design-02](https://datatracker.ietf.org/doc/draft-dcook-ppm-dap-interop-test-design/02/), to test [DAP-PPM](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/02/) implementations against each other.
+This is a reference interoperation test harness, using [draft-dcook-ppm-dap-interop-test-design-03](https://datatracker.ietf.org/doc/draft-dcook-ppm-dap-interop-test-design/03/) (forthcoming), to test [DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/) implementations against each other.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a reference interoperation test harness, using [draft-dcook-ppm-dap-interop-test-design-03](https://datatracker.ietf.org/doc/draft-dcook-ppm-dap-interop-test-design/03/) (forthcoming), to test [DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/) implementations against each other.
+This is a reference interoperation test harness, using [draft-dcook-ppm-dap-interop-test-design-03](https://datatracker.ietf.org/doc/draft-dcook-ppm-dap-interop-test-design/03/), to test [DAP](https://datatracker.ietf.org/doc/draft-ietf-ppm-dap/03/) implementations against each other.
 
 ## Prerequisites
 

--- a/src/runner/__init__.py
+++ b/src/runner/__init__.py
@@ -8,10 +8,12 @@ import time
 
 from . import containers
 from .containers import (
-    ClientContainer, AggregatorContainer, CollectorContainer,
+    ClientContainer, AggregatorContainer, CollectorContainer, InteropAPIError,
 )
 from .dap import generate_auth_token, generate_task_id
-from .models import ImageSet, TestCase
+from .models import (
+    FixedSizeQuery, ImageSet, Query, QueryType, TestCase, TimeIntervalQuery,
+)
 from .vdaf import (
     aggregate_measurements, generate_measurement, generate_vdaf_verify_key,
 )
@@ -104,11 +106,12 @@ def run_test_inner(client_container: ClientContainer,
         leader_endpoint,
         test_case.vdaf,
         collector_auth_token,
+        test_case.query_type,
     )
 
     # Fix these task parameters for now
     max_batch_query_count = 1
-    min_batch_size = 1
+    min_batch_size = test_case.measurement_count
     time_precision = 3600
     task_expiration = int(datetime.datetime(3000, 1, 1, 0, 0, 0).timestamp())
 
@@ -126,6 +129,7 @@ def run_test_inner(client_container: ClientContainer,
         time_precision,
         collector_hpke_config_base64,
         task_expiration,
+        test_case.query_type,
     )
     helper_container.add_task(
         task_id,
@@ -141,6 +145,7 @@ def run_test_inner(client_container: ClientContainer,
         time_precision,
         collector_hpke_config_base64,
         task_expiration,
+        test_case.query_type,
     )
 
     batch_interval_start = int(
@@ -163,17 +168,35 @@ def run_test_inner(client_container: ClientContainer,
     expected_aggregate_result = aggregate_measurements(
         test_case.vdaf, None, measurements)
 
-    handle = collector_container.collect_start(
-        task_id, None, batch_interval_start, batch_interval_duration)
+    query: Query
+    if test_case.query_type == QueryType.TIME_INTERVAL:
+        query = TimeIntervalQuery(
+            batch_interval_start,
+            batch_interval_duration,
+        )
+    elif test_case.query_type == QueryType.FIXED_SIZE:
+        query = FixedSizeQuery()
 
     result = None
-    for _ in range(60):
-        result = collector_container.collect_poll(handle)
+    for _ in range(5):
         if result is not None:
             break
-        time.sleep(1)
+        try:
+            handle = collector_container.collect_start(task_id, None, query)
+
+            for _ in range(30):
+                result = collector_container.collect_poll(handle)
+                if result is not None:
+                    break
+                time.sleep(1)
+            else:
+                raise Exception("Timed out waiting for collection to complete")
+
+        except InteropAPIError:
+            time.sleep(1)
+            continue
     else:
-        raise Exception("Timed out waiting for collection to complete")
+        raise Exception("Timed out waiting for collection flow")
 
     if expected_aggregate_result != result:
         raise Exception(

--- a/src/runner/__init__.py
+++ b/src/runner/__init__.py
@@ -13,7 +13,7 @@ from .containers import (
 from .dap import generate_auth_token, generate_task_id
 from .models import ImageSet, TestCase
 from .vdaf import (
-    aggregate_measurements, generate_measurement, generate_verify_key,
+    aggregate_measurements, generate_measurement, generate_vdaf_verify_key,
 )
 
 IDENTIFIER_ALPHABET = string.ascii_lowercase + string.digits
@@ -94,7 +94,7 @@ def run_test_inner(client_container: ClientContainer,
     task_id = generate_task_id()
     aggregator_auth_token = generate_auth_token("leader")
     collector_auth_token = generate_auth_token("collector")
-    verify_key = generate_verify_key(test_case.vdaf)
+    vdaf_verify_key = generate_vdaf_verify_key(test_case.vdaf)
 
     leader_endpoint = leader_container.endpoint_for_task(task_id, "leader")
     helper_endpoint = helper_container.endpoint_for_task(task_id, "helper")
@@ -120,7 +120,7 @@ def run_test_inner(client_container: ClientContainer,
         test_case.vdaf,
         aggregator_auth_token,
         collector_auth_token,
-        verify_key,
+        vdaf_verify_key,
         max_batch_query_count,
         min_batch_size,
         time_precision,
@@ -135,7 +135,7 @@ def run_test_inner(client_container: ClientContainer,
         test_case.vdaf,
         aggregator_auth_token,
         None,
-        verify_key,
+        vdaf_verify_key,
         max_batch_query_count,
         min_batch_size,
         time_precision,

--- a/src/runner/containers.py
+++ b/src/runner/containers.py
@@ -182,7 +182,7 @@ class AggregatorContainer(DAPContainer):
     def add_task(self, task_id: bytes, role: str,
                  leader_endpoint: str, helper_endpoint: str, vdaf: dict,
                  leader_token: str, collector_token: Union[str, None],
-                 verify_key: bytes, max_batch_query_count: int,
+                 vdaf_verify_key: bytes, max_batch_query_count: int,
                  min_batch_size: int, time_precision: int,
                  collector_hpke_config_base64: str, task_expiration: int):
         request_body = {
@@ -192,7 +192,7 @@ class AggregatorContainer(DAPContainer):
             "vdaf": vdaf,
             "leader_authentication_token": leader_token,
             "role": role,
-            "verify_key": encode_base64url(verify_key),
+            "vdaf_verify_key": encode_base64url(vdaf_verify_key),
             "max_batch_query_count": max_batch_query_count,
             "query_type": 1,
             "min_batch_size": min_batch_size,

--- a/src/runner/containers.py
+++ b/src/runner/containers.py
@@ -11,6 +11,18 @@ import docker  # type: ignore
 import requests
 import requests.adapters
 
+from runner.models import Query, QueryType
+
+
+class InteropAPIError(Exception):
+    "An error returned from an interop test API request."
+
+    def __init__(self, container: str, path: str, error_message: str):
+        message = (
+            f"Error from {container} upon {path} request: {error_message}"
+        )
+        super().__init__(message)
+
 
 class GeneratorStreamAdapter(io.RawIOBase):
     def __init__(self, gen):
@@ -48,7 +60,6 @@ class DAPContainer:
         # when round-tripping through the Image class.
         self.original_image = image
         self._container = container
-        self._session = requests.Session()
 
     def port(self) -> str:
         if not self._container.attrs["NetworkSettings"]["Ports"]:
@@ -80,9 +91,10 @@ class DAPContainer:
             return response_body
         else:
             error_message = response_body.get("error", "")
-            raise Exception(
-                f"Error from {self.original_image} upon {path} request: "
-                f"{error_message}"
+            raise InteropAPIError(
+                self.original_image,
+                path,
+                error_message,
             )
 
     def wait_for_ready(self):
@@ -184,7 +196,8 @@ class AggregatorContainer(DAPContainer):
                  leader_token: str, collector_token: Union[str, None],
                  vdaf_verify_key: bytes, max_batch_query_count: int,
                  min_batch_size: int, time_precision: int,
-                 collector_hpke_config_base64: str, task_expiration: int):
+                 collector_hpke_config_base64: str, task_expiration: int,
+                 query_type: QueryType):
         request_body = {
             "task_id": encode_base64url(task_id),
             "leader": leader_endpoint,
@@ -194,7 +207,7 @@ class AggregatorContainer(DAPContainer):
             "role": role,
             "vdaf_verify_key": encode_base64url(vdaf_verify_key),
             "max_batch_query_count": max_batch_query_count,
-            "query_type": 1,
+            "query_type": query_type.value,
             "min_batch_size": min_batch_size,
             "time_precision": time_precision,
             "collector_hpke_config": collector_hpke_config_base64,
@@ -202,34 +215,31 @@ class AggregatorContainer(DAPContainer):
         }
         if collector_token is not None:
             request_body["collector_authentication_token"] = collector_token
+        if query_type == QueryType.FIXED_SIZE:
+            request_body["max_batch_size"] = min_batch_size
         self.make_request("internal/test/add_task", request_body)
 
 
 class CollectorContainer(DAPContainer):
     def add_task(self, task_id: bytes, leader_endpoint: str,
-                 vdaf: dict, auth_token: str) -> str:
+                 vdaf: dict, auth_token: str, query_type: QueryType) -> str:
         request_body = {
             "task_id": encode_base64url(task_id),
             "leader": leader_endpoint,
             "vdaf": vdaf,
             "collector_authentication_token": auth_token,
-            "query_type": 1,
+            "query_type": query_type.value,
         }
         response_body = self.make_request(
             "internal/test/add_task", request_body)
         return response_body["collector_hpke_config"]
 
     def collect_start(self, task_id: bytes, _aggregation_param: None,
-                      batch_interval_start: int,
-                      batch_interval_duration: int) -> str:
+                      query: Query) -> str:
         request_body = {
             "task_id": encode_base64url(task_id),
             "agg_param": "",
-            "query": {
-                "type": 1,
-                "batch_interval_start": batch_interval_start,
-                "batch_interval_duration": batch_interval_duration,
-            }
+            "query": query.to_json(),
         }
         response_body = self.make_request(
             "internal/test/collect_start", request_body)

--- a/src/runner/models.py
+++ b/src/runner/models.py
@@ -1,4 +1,57 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
+
+
+class QueryType(Enum):
+    TIME_INTERVAL = 1
+    FIXED_SIZE = 2
+
+
+class Query(ABC):
+    @property
+    @abstractmethod
+    def query_type(self) -> QueryType:
+        ...
+
+    @abstractmethod
+    def to_json(self) -> dict:
+        ...
+
+
+class TimeIntervalQuery(Query):
+    def __init__(self,
+                 batch_interval_start: int,
+                 batch_interval_duration: int):
+        self.batch_interval_start = batch_interval_start
+        self.batch_interval_duration = batch_interval_duration
+
+    @property
+    def query_type(self) -> QueryType:
+        return QueryType.TIME_INTERVAL
+
+    def to_json(self) -> dict:
+        return {
+            "type": self.query_type.value,
+            "batch_interval_start": self.batch_interval_start,
+            "batch_interval_duration": self.batch_interval_duration,
+        }
+
+
+class FixedSizeQuery(Query):
+    def __init__(self):
+        pass
+
+    @property
+    def query_type(self) -> QueryType:
+        return QueryType.FIXED_SIZE
+
+    def to_json(self) -> dict:
+        return {
+            "type": self.query_type.value,
+            # Only the current_batch query subtype is supported for now
+            "subtype": 1,
+        }
 
 
 @dataclass(frozen=True)
@@ -6,6 +59,7 @@ class TestCase:
     name: str
     vdaf: dict
     measurement_count: int
+    query_type: QueryType
 
 
 @dataclass(frozen=True)

--- a/src/runner/test_cases.py
+++ b/src/runner/test_cases.py
@@ -1,29 +1,62 @@
-from .models import TestCase
+from .models import QueryType, TestCase
 
 TEST_CASES = [
-    TestCase("prio3_count_small", {"type": "Prio3Aes128Count"}, 10),
-    TestCase("prio3_count_medium", {"type": "Prio3Aes128Count"}, 250),
-    TestCase("prio3_count_large", {"type": "Prio3Aes128Count"}, 5000),
-    TestCase("prio3_sum_1_bit", {"type": "Prio3Aes128Sum", "bits": "1"}, 10),
-    TestCase("prio3_sum_8_bits", {"type": "Prio3Aes128Sum", "bits": "8"}, 10),
     TestCase(
-        "prio3_sum_64_bits",
+        "time_prio3_count_small",
+        {"type": "Prio3Aes128Count"},
+        10,
+        QueryType.TIME_INTERVAL,
+    ),
+    TestCase(
+        "time_prio3_count_medium",
+        {"type": "Prio3Aes128Count"},
+        250,
+        QueryType.TIME_INTERVAL,
+    ),
+    TestCase(
+        "time_prio3_count_large",
+        {"type": "Prio3Aes128Count"},
+        5000,
+        QueryType.TIME_INTERVAL,
+    ),
+    TestCase(
+        "time_prio3_sum_1_bit",
+        {
+            "type": "Prio3Aes128Sum",
+            "bits": "1",
+        },
+        10,
+        QueryType.TIME_INTERVAL,
+    ),
+    TestCase(
+        "time_prio3_sum_8_bits",
+        {
+            "type": "Prio3Aes128Sum",
+            "bits": "8",
+        },
+        10,
+        QueryType.TIME_INTERVAL,
+    ),
+    TestCase(
+        "time_prio3_sum_64_bits",
         {
             "type": "Prio3Aes128Sum",
             "bits": "64",
         },
         10,
+        QueryType.TIME_INTERVAL,
     ),
     TestCase(
-        "prio3_histogram_5_buckets",
+        "time_prio3_histogram_5_buckets",
         {
             "type": "Prio3Aes128Histogram",
             "buckets": ["1", "3", "10", "30"],
         },
         10,
+        QueryType.TIME_INTERVAL,
     ),
     TestCase(
-        "prio3_histogram_12_buckets",
+        "time_prio3_histogram_12_buckets",
         {
             "type": "Prio3Aes128Histogram",
             "buckets": [
@@ -31,5 +64,71 @@ TEST_CASES = [
             ],
         },
         10,
+        QueryType.TIME_INTERVAL,
+    ),
+    TestCase(
+        "fixed_prio3_count_small",
+        {"type": "Prio3Aes128Count"},
+        10,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_count_medium",
+        {"type": "Prio3Aes128Count"},
+        250,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_count_large",
+        {"type": "Prio3Aes128Count"},
+        5000,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_sum_1_bit",
+        {
+            "type": "Prio3Aes128Sum",
+            "bits": "1",
+        },
+        10,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_sum_8_bits",
+        {
+            "type": "Prio3Aes128Sum",
+            "bits": "8",
+        },
+        10,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_sum_64_bits",
+        {
+            "type": "Prio3Aes128Sum",
+            "bits": "64",
+        },
+        10,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_histogram_5_buckets",
+        {
+            "type": "Prio3Aes128Histogram",
+            "buckets": ["1", "3", "10", "30"],
+        },
+        10,
+        QueryType.FIXED_SIZE,
+    ),
+    TestCase(
+        "fixed_prio3_histogram_12_buckets",
+        {
+            "type": "Prio3Aes128Histogram",
+            "buckets": [
+                "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10",
+            ],
+        },
+        10,
+        QueryType.FIXED_SIZE,
     ),
 ]

--- a/src/runner/test_cases.py
+++ b/src/runner/test_cases.py
@@ -3,9 +3,7 @@ from .models import TestCase
 TEST_CASES = [
     TestCase("prio3_count_small", {"type": "Prio3Aes128Count"}, 10),
     TestCase("prio3_count_medium", {"type": "Prio3Aes128Count"}, 250),
-    # The large test is commented out for now because Janus can't handle the
-    # high throughput without failing some aggregation jobs.
-    # TestCase("prio3_count_large", {"type": "Prio3Aes128Count"}, 5000),
+    TestCase("prio3_count_large", {"type": "Prio3Aes128Count"}, 5000),
     TestCase("prio3_sum_1_bit", {"type": "Prio3Aes128Sum", "bits": "1"}, 10),
     TestCase("prio3_sum_8_bits", {"type": "Prio3Aes128Sum", "bits": "8"}, 10),
     TestCase(

--- a/src/runner/vdaf.py
+++ b/src/runner/vdaf.py
@@ -60,7 +60,7 @@ def aggregate_measurements(vdaf_dict: dict, _aggregation_param: None,
     raise Exception(f"Unsupported VDAF: {vdaf_type}")
 
 
-def generate_verify_key(vdaf_dict: dict) -> bytes:
+def generate_vdaf_verify_key(vdaf_dict: dict) -> bytes:
     """Generate a verification key for a VDAF"""
     vdaf_type = vdaf_dict["type"]
     if vdaf_type in ("Prio3Aes128Count", "Prio3Aes128Sum",


### PR DESCRIPTION
This adds DAP-03 support, including fixed size queries, and a breaking API change to rename `verify_key` to `vdaf_verify_key`.